### PR TITLE
Fixed typo on README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ The final project part consists of:
 ```json
 {
     "Project": {
-        "Name": "HelloWorld", <----- Essential: your project name, all stacks wil be prefixed with [Project.Name+Project.Stage]
-        "Stage": "Demo",      <----- Essential: your project stage, all stacks wil be prefixed with [Project.Name+Project.Stage]
+        "Name": "HelloWorld", <----- Essential: your project name, all stacks will be prefixed with [Project.Name+Project.Stage]
+        "Stage": "Demo",      <----- Essential: your project stage, all stacks will be prefixed with [Project.Name+Project.Stage]
         "Account": "75157*******", <----- Essential: update according to your AWS Account
         "Region": "us-east-2",     <----- Essential: update according to your target resion
         "Profile": "cdk-demo"      <----- Essential: AWS Profile, keep empty string if no profile configured


### PR DESCRIPTION
 - `wil` -> `will`

*Issue #, if available:*

*Description of changes:*
There are two simple typo. `wil` on README.md (line number 156, 157) should be `will`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
